### PR TITLE
[QuickBooks→Salesforce] add sandbox metadata sync

### DIFF
--- a/sync_sandbox.sh
+++ b/sync_sandbox.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ensure SFDX source folders exist
+mkdir -p force-app/main/default/classes force-app/main/default/triggers
+
+# verify authentication using existing default username
+sfdx force:org:display --targetusername "$SFDX_DEFAULTUSERNAME" --json > /dev/null
+
+# retrieve all Apex classes and triggers from the sandbox
+sfdx force:source:retrieve -m ApexClass,ApexTrigger --targetusername "$SFDX_DEFAULTUSERNAME"
+
+# stage new or updated files
+git add force-app/main/default
+
+# commit and push if there are changes
+if git diff --cached --quiet; then
+    echo "\u2713 no changes to sync."
+else
+    git commit -m "chore: sync metadata from sandbox"
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    git push origin "$current_branch"
+fi
+


### PR DESCRIPTION
## Summary
- add script to sync metadata from sandbox via sfdx

## Testing
- `bash -n sync_sandbox.sh`
- `git push origin work` *(fails: remote origin not found)*

------
https://chatgpt.com/codex/tasks/task_e_685327e30b0083229b5eb6e7c41961e2