### PR TITLE
[QuickBooks→Salesforce] add customer sync batch and fix customer ID references

### DIFF
--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
@@ -1,0 +1,16 @@
+public with sharing class QuickBooksCustomerSyncBatch implements Database.Batchable<SObject>, Database.AllowsCallouts {
+    public Database.QueryLocator start(Database.BatchableContext bc) {
+        return Database.getQueryLocator([
+            SELECT Id, DBA_Name__c, QuickBooks_Email__c,
+                BillingStreet, BillingCity, BillingState, BillingPostalCode,
+                QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c
+            FROM Account WHERE Type = 'Customer'
+        ]);
+    }
+    public void execute(Database.BatchableContext bc, List<Account> scope) {
+        for (Account acct : scope) {
+            QuickBooksService.createOrUpdateCustomer(acct);
+        }
+    }
+    public void finish(Database.BatchableContext bc) {}
+}

--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls-meta.xml
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls
@@ -1,0 +1,20 @@
+@IsTest
+private class QuickBooksCustomerSyncBatchTest {
+    class Mock implements HttpCalloutMock {
+        public HTTPResponse respond(HTTPRequest req) {
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(200);
+            res.setBody('{}');
+            return res;
+        }
+    }
+    @IsTest static void testBatch() {
+        System.Test.setMock(HttpCalloutMock.class, new Mock());
+        Account a = new Account(Name='Acct', DBA_Name__c='DBA', QuickBooks_Email__c='a@example.com');
+        insert a;
+        Test.startTest();
+        Database.executeBatch(new QuickBooksCustomerSyncBatch(), 1);
+        Test.stopTest();
+        System.assertEquals('BatchApexWorker', [SELECT JobType FROM AsyncApexJob ORDER BY CreatedDate DESC LIMIT 1].JobType);
+    }
+}

--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls-meta.xml
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QuickBooksService.cls
+++ b/force-app/main/default/classes/QuickBooksService.cls
@@ -27,12 +27,12 @@ public with sharing class QuickBooksService {
         QuickBooksApi.send(method, resource, body);
     }
 
-    public static void createOrUpdateInvoice(rtms__CustomerInvoice__c inv) {
+    public static void createOrUpdateInvoice(rtms__CustomerInvoice__c inv, String qbCustomerId) {
         Boolean isUpdate = String.isNotBlank(inv.QuickBooks_Invoice_Id__c);
         String method = isUpdate ? 'PATCH' : 'POST';
         String resource = baseUrl('/invoice');
         Map<String,Object> body = new Map<String,Object>{
-            'CustomerRef' => new Map<String,Object>{'value'=>inv.Account__c},
+            'CustomerRef' => new Map<String,Object>{'value'=>qbCustomerId},
             'DocNumber' => inv.Invoice_Number__c,
             'TxnDate' => (inv.Invoice_Date__c != null ? String.valueOf(inv.Invoice_Date__c) : null),
             'DueDate' => (inv.Invoice_Due_Date__c != null ? String.valueOf(inv.Invoice_Due_Date__c) : null),
@@ -67,10 +67,10 @@ public with sharing class QuickBooksService {
         QuickBooksApi.send('POST', resource, body);
     }
 
-    public static void createPayment(rtms__CustomerPayment__c pay) {
+    public static void createPayment(rtms__CustomerPayment__c pay, String qbCustomerId, String qbInvoiceId) {
         String resource = baseUrl('/payment');
         Map<String,Object> body = new Map<String,Object>{
-            'CustomerRef' => new Map<String,Object>{'value'=>pay.Account__c},
+            'CustomerRef' => new Map<String,Object>{'value'=>qbCustomerId},
             'TotalAmt' => pay.rtms__Payment_Amount__c,
             'TxnDate' => (pay.rtms__Payment_Date__c != null ? String.valueOf(pay.rtms__Payment_Date__c) : null),
             'PaymentRefNum' => pay.rtms__Check_Reference_Number__c,
@@ -79,7 +79,7 @@ public with sharing class QuickBooksService {
                     'Amount' => pay.rtms__Payment_Amount__c,
                     'LinkedTxn' => new List<Object>{
                         new Map<String,Object>{
-                            'TxnId' => pay.CustomerInvoice__c,
+                            'TxnId' => qbInvoiceId,
                             'TxnType' => 'Invoice'
                         }
                     }

--- a/force-app/main/default/classes/QuickBooksServiceTest.cls
+++ b/force-app/main/default/classes/QuickBooksServiceTest.cls
@@ -22,7 +22,10 @@ private class QuickBooksServiceTest {
         System.Test.setMock(HttpCalloutMock.class, new Mock());
         rtms__Load__c load = new rtms__Load__c(Name='L', rtms__Total_Weight__c=1);
         insert load;
-        rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='inv', rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
+        Account acct = new Account(Name='A', QuickBooks_Customer_Id__c='QB1');
+        insert acct;
+        rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='inv', Account__c=acct.Id,
+            rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
         insert inv;
         SObject acc = Schema.getGlobalDescribe().get('rtms__Accessorial__c').newSObject();
         acc.put('Name', 'A');
@@ -32,14 +35,16 @@ private class QuickBooksServiceTest {
         rtms__CustomerInvoiceAccessorial__c line = new rtms__CustomerInvoiceAccessorial__c(Name='line', rtms__Charge__c=1, QBO_Item_Id__c='1', rtms__Unit_Price__c=1, rtms__Quantity__c=1);
         line.put('rtms__Customer_Invoice__c', inv.Id);
         line.put('rtms__Accessorial__c', accId);
-        rtms__CustomerPayment__c pay = new rtms__CustomerPayment__c(rtms__Payment_Amount__c=1, rtms__Check_Reference_Number__c='1');
+        rtms__CustomerPayment__c pay = new rtms__CustomerPayment__c(rtms__Payment_Amount__c=1,
+            rtms__Check_Reference_Number__c='1');
         pay.put('rtms__Customer_Invoice__c', inv.Id);
         pay.put('rtms__Load__c', load.Id);
+        pay.put('Account__c', acct.Id);
         insert pay;
         System.Test.startTest();
-        QuickBooksService.createOrUpdateInvoice(inv);
+        QuickBooksService.createOrUpdateInvoice(inv, acct.QuickBooks_Customer_Id__c);
         QuickBooksService.createInvoiceLines(new List<rtms__CustomerInvoiceAccessorial__c>{line}, '1');
-        QuickBooksService.createPayment(pay);
+        QuickBooksService.createPayment(pay, acct.QuickBooks_Customer_Id__c, '1');
         System.Test.stopTest();
     }
 }

--- a/force-app/main/default/classes/QuickBooksSyncJob.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJob.cls
@@ -16,12 +16,12 @@ public with sharing class QuickBooksSyncJob implements Queueable, Database.Allow
                 QuickBooksService.createOrUpdateCustomer(acct);
             }
         } else if (sObjectType == 'rtms__CustomerInvoice__c') {
-            for (rtms__CustomerInvoice__c inv : [SELECT Id, Account__c, Invoice_Number__c,
+            for (rtms__CustomerInvoice__c inv : [SELECT Id, Account__c, Account__r.QuickBooks_Customer_Id__c, Invoice_Number__c,
                     Invoice_Date__c, Invoice_Due_Date__c,
                     Invoice_Comments__c, QuickBooks_Invoice_Id__c,
                     QuickBooks_Invoice_SyncToken__c
                 FROM rtms__CustomerInvoice__c WHERE Id IN :recordIds]) {
-                QuickBooksService.createOrUpdateInvoice(inv);
+                QuickBooksService.createOrUpdateInvoice(inv, inv.Account__r.QuickBooks_Customer_Id__c);
             }
         } else if (sObjectType == 'rtms__CustomerInvoiceAccessorial__c') {
             List<rtms__CustomerInvoiceAccessorial__c> lines = [SELECT Id, Name, rtms__Charge__c,
@@ -44,11 +44,12 @@ public with sharing class QuickBooksSyncJob implements Queueable, Database.Allow
                 }
             }
         } else if (sObjectType == 'rtms__CustomerPayment__c') {
-            for (rtms__CustomerPayment__c pay : [SELECT Id, Account__c,
+            for (rtms__CustomerPayment__c pay : [SELECT Id, Account__c, Account__r.QuickBooks_Customer_Id__c,
                     rtms__Payment_Amount__c, rtms__Payment_Date__c,
-                    rtms__Check_Reference_Number__c, CustomerInvoice__c
+                    rtms__Check_Reference_Number__c, CustomerInvoice__c, CustomerInvoice__r.QuickBooks_Invoice_Id__c
                 FROM rtms__CustomerPayment__c WHERE Id IN :recordIds]) {
-                QuickBooksService.createPayment(pay);
+                QuickBooksService.createPayment(pay, pay.Account__r.QuickBooks_Customer_Id__c,
+                        pay.CustomerInvoice__r.QuickBooks_Invoice_Id__c);
             }
         }
     }

--- a/force-app/main/default/classes/QuickBooksSyncJobTest.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJobTest.cls
@@ -13,8 +13,11 @@ private class QuickBooksSyncJobTest {
         System.Test.setMock(HttpCalloutMock.class, new Mock());
         rtms__Load__c load = new rtms__Load__c(Name='Load', rtms__Total_Weight__c=1);
         insert load;
+        Account a = new Account(Name='Acct', QuickBooks_Customer_Id__c='QB1');
+        insert a;
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(
             Name='Inv',
+            Account__c=a.Id,
             rtms__Load__c=load.Id,
             rtms__Invoice_Date__c=Date.today(),
             rtms__Invoice_Due_Date__c=Date.today().addDays(1),


### PR DESCRIPTION
## Summary
- add `QuickBooksCustomerSyncBatch` for syncing existing customer accounts
- update `QuickBooksService` to take QuickBooks customer/invoice IDs
- pull QuickBooks IDs in `QuickBooksSyncJob`
- adjust tests and add unit test for new batch class

## Testing
- `sfdx force:apex:test:run --codecoverage --resultformat human`
- `sfdx force:source:deploy --checkonly -p force-app/main/default --testlevel RunLocalTests`


------
https://chatgpt.com/codex/tasks/task_e_6855d85c646c8322bbae2034c6a9e1f7