### PR TITLE
[QuickBooks→Salesforce] remove custom Test wrapper

### DIFF
--- a/destructive/destructiveChanges.xml
+++ b/destructive/destructiveChanges.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
-        <members>Test</members>
         <name>ApexClass</name>
     </types>
     <version>57.0</version>

--- a/force-app/main/default/classes/Test.cls
+++ b/force-app/main/default/classes/Test.cls
@@ -1,8 +1,0 @@
-public class Test {
-    public static void startTest() { System.Test.startTest(); }
-    public static void stopTest() { System.Test.stopTest(); }
-    public static void setMock(System.Type interfaceType, Object mock) {
-        System.Test.setMock(interfaceType, mock);
-    }
-    public static Boolean isRunningTest() { return System.Test.isRunningTest(); }
-}

--- a/force-app/main/default/classes/Test.cls-meta.xml
+++ b/force-app/main/default/classes/Test.cls-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
-    <status>Active</status>
-</ApexClass>


### PR DESCRIPTION
## Summary
- delete the custom `Test` class
- remove class from `destructiveChanges.xml`

## Testing
- `sfdx force:apex:test:run --codecoverage --resultformat human -u QuickBooksSandbox` *(fails: No authorization information found)*
- `sfdx force:source:deploy --checkonly -p force-app/main/default --testlevel RunLocalTests -u QuickBooksSandbox` *(fails: No authorization information found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c572a1c8322ab33d1c12ac10a1d