### PR TITLE
[QuickBooks→Salesforce] disable skipDml in test

### DIFF
--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatchTest.cls
@@ -15,7 +15,7 @@ private class QuickBooksCustomerSyncBatchTest {
     @IsTest static void testBatch() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
-        QuickBooksCustomerSyncBatch.skipDml = true;
+        QuickBooksCustomerSyncBatch.skipDml = false;
         Account a = new Account(Name='Acct', Type='Customer');
         insert a;
         insert new Contact(LastName='Bill', Email='a@example.com', Title='Billing', AccountId=a.Id);


### PR DESCRIPTION
## Summary
- update `QuickBooksCustomerSyncBatchTest` so the batch executes DML

## Verified Test Coverage
- `sfdx force:apex:test:run --codecoverage --resultformat human` *(fails: No authorization information)*

## Validation
- ❌ `sfdx force:apex:test:run --codecoverage --resultformat human`

Consider providing sandbox credentials or running tests in an authenticated environment.

------
https://chatgpt.com/codex/tasks/task_e_685f0c54db9883228fe6ede5157bf2d4