### PR TITLE
[QuickBooks→Salesforce] Update payment scheduler references

### DIFF
--- a/force-app/main/default/classes/QuickBooksPaymentScheduler.cls
+++ b/force-app/main/default/classes/QuickBooksPaymentScheduler.cls
@@ -1,9 +1,9 @@
 public with sharing class QuickBooksPaymentScheduler implements Schedulable {
     public void execute(SchedulableContext context) {
         if (Test.isRunningTest()) {
-            new QuickBooksSyncJob('Payments', new List<Id>()).execute(null);
+            new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()).execute(null);
         } else {
-            System.enqueueJob(new QuickBooksSyncJob('Payments', new List<Id>()));
+            System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()));
         }
     }
 }

--- a/force-app/main/default/classes/QuickBooksService.cls
+++ b/force-app/main/default/classes/QuickBooksService.cls
@@ -1,5 +1,6 @@
 public with sharing class QuickBooksService {
-    @TestVisible static Boolean skipDml = false;
+    @TestVisible
+    public static Boolean skipDml = false;
     private static final String COMPANY_ID = '9341454816381446';
     private static String baseUrl(String path) {
         return '/v3/company/' + COMPANY_ID + path;


### PR DESCRIPTION
## Summary
- use `rtms__CustomerPayment__c` in the payment scheduler
- expose `skipDml` flag in `QuickBooksService`

## Verified Test Coverage
- `sfdx force:apex:test:run --codecoverage --resultformat human -t QuickBooksPaymentSchedulerTest,QuickBooksApiTest`
- `sfdx force:source:deploy --checkonly -p force-app/main/default --testlevel RunSpecifiedTests -r QuickBooksPaymentSchedulerTest,QuickBooksApiTest`

## Validation-Only Deploy
- ✅ validation deploy succeeded using specified tests


------
https://chatgpt.com/codex/tasks/task_e_685f0c56160c8322838e7810485cf75c