### PR TITLE
[QuickBooks→Salesforce] Include DBA_Name__c in customer sync queries

### DIFF
--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
@@ -2,7 +2,7 @@ public with sharing class QuickBooksCustomerSyncBatch implements Database.Batcha
     @TestVisible static Boolean skipDml = false;
     public Database.QueryLocator start(Database.BatchableContext bc) {
         return Database.getQueryLocator([
-            SELECT Id, Name, QuickBooks_Email__c,
+            SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
                 BillingStreet, BillingCity, BillingState, BillingPostalCode,
                 QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c,
                 (SELECT Id, Email, Title FROM Contacts WHERE Title = 'Billing')

--- a/force-app/main/default/classes/QuickBooksSyncJob.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJob.cls
@@ -9,7 +9,7 @@ public with sharing class QuickBooksSyncJob implements Queueable, Database.Allow
 
     public void execute(QueueableContext context) {
         if (sObjectType == 'Account') {
-            for (Account acct : [SELECT Id, Name, QuickBooks_Email__c,
+            for (Account acct : [SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
                     BillingStreet, BillingCity, BillingState, BillingPostalCode,
                     QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c,
                     (SELECT Id, Email, Title FROM Contacts WHERE Title = 'Billing')


### PR DESCRIPTION
## Summary
- select DBA_Name__c when queuing customer sync jobs
- ensure customer sync batch also selects DBA_Name__c

## Testing
- `sfdx force:apex:test:run --codecoverage --resultformat human` *(fails: SObject row was retrieved via SOQL without querying the requested field: Account.DBA_Name__c)*

------
https://chatgpt.com/codex/tasks/task_e_685fccb2a53083228dd9f575c1dc742a