### PR TITLE
[QuickBooks→Salesforce] load full account record when updating customer

### DIFF
--- a/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
+++ b/force-app/main/default/classes/QuickBooksCustomerSyncBatch.cls
@@ -2,7 +2,7 @@ public with sharing class QuickBooksCustomerSyncBatch implements Database.Batcha
     @TestVisible static Boolean skipDml = false;
     public Database.QueryLocator start(Database.BatchableContext bc) {
         return Database.getQueryLocator([
-            SELECT Id, Name, QuickBooks_Email__c,
+            SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
                 BillingStreet, BillingCity, BillingState, BillingPostalCode,
                 QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c,
                 (SELECT Id, Email, Title FROM Contacts WHERE Title = 'Billing')

--- a/force-app/main/default/classes/QuickBooksService.cls
+++ b/force-app/main/default/classes/QuickBooksService.cls
@@ -19,6 +19,16 @@ public with sharing class QuickBooksService {
         Boolean isUpdate = String.isNotBlank(acct.QuickBooks_Customer_Id__c);
         String method = isUpdate ? 'PATCH' : 'POST';
         String resource = baseUrl('/customer');
+        if (acct.Id == null && isUpdate) {
+            acct = [
+                SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
+                       BillingStreet, BillingCity, BillingState, BillingPostalCode,
+                       QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c
+                  FROM Account
+                 WHERE QuickBooks_Customer_Id__c = :acct.QuickBooks_Customer_Id__c
+                 LIMIT 1
+            ];
+        }
         String email = acct.QuickBooks_Email__c;
         if (String.isBlank(email) && acct.Id != null) {
             List<Contact> cons = [SELECT Email FROM Contact WHERE AccountId = :acct.Id AND Title = 'Billing' LIMIT 1];

--- a/force-app/main/default/classes/QuickBooksSyncJob.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJob.cls
@@ -9,7 +9,7 @@ public with sharing class QuickBooksSyncJob implements Queueable, Database.Allow
 
     public void execute(QueueableContext context) {
         if (sObjectType == 'Account') {
-            for (Account acct : [SELECT Id, Name, QuickBooks_Email__c,
+            for (Account acct : [SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
                     BillingStreet, BillingCity, BillingState, BillingPostalCode,
                     QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c,
                     (SELECT Id, Email, Title FROM Contacts WHERE Title = 'Billing')


### PR DESCRIPTION
## Summary
- query the Account by QuickBooks ID inside `createOrUpdateCustomer`
- include `DBA_Name__c` and other referenced fields in the select list

## Testing
- No tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_685fccb2a53083228dd9f575c1dc742a