### PR TITLE
Fix QuickBooks async guards

### DIFF
--- a/force-app/main/default/classes/CustomerInvoiceTriggerHandler.cls
+++ b/force-app/main/default/classes/CustomerInvoiceTriggerHandler.cls
@@ -7,7 +7,7 @@ public with sharing class CustomerInvoiceTriggerHandler {
                 toSync.add(inv.Id);
             }
         }
-        if (!toSync.isEmpty() && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+        if (!toSync.isEmpty() && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
             System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerInvoice__c', toSync));
         }
     }

--- a/force-app/main/default/classes/QuickBooksScheduler.cls
+++ b/force-app/main/default/classes/QuickBooksScheduler.cls
@@ -19,7 +19,7 @@ public with sharing class QuickBooksScheduler implements Schedulable {
         if (mode == 'Payment') {
             if (Test.isRunningTest()) {
                 new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()).execute(null);
-            } else {
+            } else if (!QuickBooksSyncJob.skipAsync) {
                 System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()));
             }
         } else {

--- a/force-app/main/default/classes/QuickBooksService.cls
+++ b/force-app/main/default/classes/QuickBooksService.cls
@@ -36,7 +36,6 @@ public with sharing class QuickBooksService {
         }
         String method = isUpdate ? 'PATCH' : 'POST';
         String resource = baseUrl('/customer');
-2u8ucv-codex/locate-quickbooks-id-write-location
         if ((acct.Id == null && isUpdate) || (acct.Id != null && acct.Name == null)) {
             acct = [
                 SELECT Id,
@@ -49,12 +48,16 @@ public with sharing class QuickBooksService {
                        BillingPostalCode,
                        QuickBooks_Customer_Id__c,
                        QuickBooks_Customer_SyncToken__c
+                  FROM Account
+                 WHERE Id = :acct.Id
+                 LIMIT 1
+            ];
+        }
         if (acct.Id == null && isUpdate) {
             acct = [
                 SELECT Id, Name, DBA_Name__c, QuickBooks_Email__c,
                        BillingStreet, BillingCity, BillingState, BillingPostalCode,
                        QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c
-main
                   FROM Account
                  WHERE QuickBooks_Customer_Id__c = :acct.QuickBooks_Customer_Id__c
                  LIMIT 1

--- a/force-app/main/default/classes/QuickBooksServiceTest.cls
+++ b/force-app/main/default/classes/QuickBooksServiceTest.cls
@@ -12,6 +12,7 @@ private class QuickBooksServiceTest {
     @IsTest static void testCreateCustomer() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         Account acct = new Account(Name='a', BillingStreet='1', BillingCity='Chicago', BillingStateCode='IL', BillingCountryCode='US', BillingPostalCode='60606');
         insert acct;
@@ -21,11 +22,13 @@ private class QuickBooksServiceTest {
         Test.stopTest();
         System.assertEquals('99', result.id);
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testCreateCustomerUsesContactEmail() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         Account acct = new Account(Name='OnlyName', BillingStreet='1', BillingCity='Chicago', BillingStateCode='IL', BillingCountryCode='US', BillingPostalCode='60606');
         insert acct;
@@ -35,6 +38,7 @@ private class QuickBooksServiceTest {
         Test.stopTest();
         System.assertEquals('99', result.id);
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testCreateInvoiceLineAndPayment() {
@@ -61,11 +65,13 @@ private class QuickBooksServiceTest {
         QuickBooksService.createInvoiceLines(new List<rtms__CustomerInvoiceAccessorial__c>{line}, '1', '0');
         QuickBooksService.createPayment(pay, acct.QuickBooks_Customer_Id__c, '1');
         Test.stopTest();
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testUpdateCustomerAndInvoice() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         rtms__Load__c load = new rtms__Load__c(Name='L3', rtms__Total_Weight__c=1);
         Account acct = new Account(Name='B', BillingStreet='1', BillingCity='Chicago', BillingStateCode='IL', BillingCountryCode='US', BillingPostalCode='60606',
@@ -81,5 +87,6 @@ private class QuickBooksServiceTest {
         Test.stopTest();
         System.assertEquals('99', res.id);
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
     }
 }

--- a/force-app/main/default/classes/QuickBooksSyncJob.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJob.cls
@@ -1,4 +1,6 @@
 public with sharing class QuickBooksSyncJob implements Queueable, Database.AllowsCallouts {
+    @TestVisible
+    public static Boolean skipAsync = false;
     private String sObjectType;
     private List<Id> recordIds;
 

--- a/force-app/main/default/classes/QuickBooksSyncJobTest.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJobTest.cls
@@ -12,6 +12,7 @@ private class QuickBooksSyncJobTest {
     @IsTest static void testQueueable() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         rtms__Load__c load = new rtms__Load__c(Name='Load', rtms__Total_Weight__c=1);
         insert load;
@@ -32,11 +33,13 @@ private class QuickBooksSyncJobTest {
         new QuickBooksSyncJob('rtms__CustomerInvoice__c', ids).execute(null);
         Test.stopTest();
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testAccountQueueable() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         Account a = new Account(Name='Acct');
         insert a;
@@ -45,6 +48,7 @@ private class QuickBooksSyncJobTest {
         new QuickBooksSyncJob('Account', new List<Id>{a.Id}).execute(null);
         Test.stopTest();
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
         a = [SELECT QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c FROM Account WHERE Id = :a.Id];
         System.assertEquals('77', a.QuickBooks_Customer_Id__c);
         System.assertEquals('2', a.QuickBooks_Customer_SyncToken__c);
@@ -53,6 +57,7 @@ private class QuickBooksSyncJobTest {
     @IsTest static void testAccessorialQueueable() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         QuickBooksService.skipDml = true;
         rtms__Load__c load = new rtms__Load__c(Name='Load2', rtms__Total_Weight__c=1);
         insert load;
@@ -77,6 +82,7 @@ private class QuickBooksSyncJobTest {
         new QuickBooksSyncJob('rtms__CustomerInvoiceAccessorial__c', new List<Id>{line.Id}).execute(null);
         Test.stopTest();
         QuickBooksService.skipDml = false;
+        QuickBooksSyncJob.skipAsync = false;
     }
 
 }


### PR DESCRIPTION
## Summary
- add skipAsync flag to QuickBooksSyncJob
- respect skipAsync in CustomerInvoiceTriggerHandler and scheduler
- update QuickBooksService query and remove leftover placeholder
- disable queueables in tests

## Testing
- `sfdx force:apex:test:run -u QuickBooksSandbox -c -r human -w 10` *(fails: Too many async jobs; uncommitted work)*

------
https://chatgpt.com/codex/tasks/task_e_68608e05a5348322bd16a8fe8b30df0d