### PR TITLE
Fix triggers to honor skipAsync in tests

### DIFF
--- a/force-app/main/default/classes/QuickBooksTriggersTest.cls
+++ b/force-app/main/default/classes/QuickBooksTriggersTest.cls
@@ -12,16 +12,19 @@ private class QuickBooksTriggersTest {
     @IsTest static void testAccountTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         Account a = new Account(Name='A');
         Test.startTest();
         insert a;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testPaymentTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         rtms__Load__c load = new rtms__Load__c(Name='L', rtms__Total_Weight__c=1);
         insert load;
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='Inv2', rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
@@ -33,11 +36,13 @@ private class QuickBooksTriggersTest {
         insert p;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testAccessorialTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         rtms__Load__c load = new rtms__Load__c(Name='L2', rtms__Total_Weight__c=1);
         insert load;
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='Inv3', rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
@@ -54,5 +59,6 @@ private class QuickBooksTriggersTest {
         insert line;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 }

--- a/force-app/main/default/triggers/AccountQuickBooksTrigger.trigger
+++ b/force-app/main/default/triggers/AccountQuickBooksTrigger.trigger
@@ -1,5 +1,5 @@
 trigger AccountQuickBooksTrigger on Account (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('Account', new List<Id>(Trigger.newMap.keySet())));
     }
 }

--- a/force-app/main/default/triggers/CustomerInvoiceAccessorialTrigger.trigger
+++ b/force-app/main/default/triggers/CustomerInvoiceAccessorialTrigger.trigger
@@ -1,5 +1,5 @@
 trigger CustomerInvoiceAccessorialTrigger on rtms__CustomerInvoiceAccessorial__c (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerInvoiceAccessorial__c', new List<Id>(Trigger.newMap.keySet())));
     }
 }

--- a/force-app/main/default/triggers/CustomerPaymentTrigger.trigger
+++ b/force-app/main/default/triggers/CustomerPaymentTrigger.trigger
@@ -1,5 +1,5 @@
 trigger CustomerPaymentTrigger on rtms__CustomerPayment__c (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>(Trigger.newMap.keySet())));
     }
 }


### PR DESCRIPTION
## Summary
- avoid enqueuing QuickBooks jobs during tests by checking `QuickBooksSyncJob.skipAsync`
- update trigger unit tests to disable async jobs

## Testing
- `./setup_codex.sh validate sandbox` *(fails: Invalid or missing SFDX auth URL)*

------
https://chatgpt.com/codex/tasks/task_e_686150ddb4dc8322aae8bf8f54489e02