### PR TITLE
Fix triggers to honor skipAsync in tests

### DIFF
--- a/force-app/main/default/classes/QuickBooksScheduler.cls
+++ b/force-app/main/default/classes/QuickBooksScheduler.cls
@@ -17,10 +17,10 @@ public with sharing class QuickBooksScheduler implements Schedulable {
 
     public void execute(SchedulableContext context) {
         if (mode == 'Payment') {
-            if (Test.isRunningTest()) {
-                new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()).execute(null);
-            } else if (!QuickBooksSyncJob.skipAsync) {
+            if (!QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
                 System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()));
+            } else {
+                new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>()).execute(null);
             }
         } else {
             if (Test.isRunningTest()) {

--- a/force-app/main/default/classes/QuickBooksService.cls
+++ b/force-app/main/default/classes/QuickBooksService.cls
@@ -19,8 +19,7 @@ public with sharing class QuickBooksService {
         Boolean isUpdate = String.isNotBlank(acct.QuickBooks_Customer_Id__c);
         if ((acct.Id == null && isUpdate) || acct.Name == null || acct.DBA_Name__c == null) {
             acct = [
-                SELECT Id,
-                       Name,
+                SELECT Id, Name,
                        DBA_Name__c,
                        QuickBooks_Email__c,
                        BillingStreet,
@@ -38,8 +37,7 @@ public with sharing class QuickBooksService {
         String resource = baseUrl('/customer');
         if ((acct.Id == null && isUpdate) || (acct.Id != null && acct.Name == null)) {
             acct = [
-                SELECT Id,
-                       Name,
+                SELECT Id, Name,
                        DBA_Name__c,
                        QuickBooks_Email__c,
                        BillingStreet,

--- a/force-app/main/default/classes/QuickBooksServiceTest.cls
+++ b/force-app/main/default/classes/QuickBooksServiceTest.cls
@@ -23,6 +23,7 @@ private class QuickBooksServiceTest {
         System.assertEquals('99', result.id);
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 
     @IsTest static void testCreateCustomerUsesContactEmail() {
@@ -39,11 +40,13 @@ private class QuickBooksServiceTest {
         System.assertEquals('99', result.id);
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 
     @IsTest static void testCreateInvoiceLineAndPayment() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         rtms__Load__c load = new rtms__Load__c(Name='L', rtms__Total_Weight__c=1);
         Account acct = new Account(Name='A', QuickBooks_Customer_Id__c='QB1');
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='inv', Account__c=acct.Id,
@@ -66,6 +69,7 @@ private class QuickBooksServiceTest {
         QuickBooksService.createPayment(pay, acct.QuickBooks_Customer_Id__c, '1');
         Test.stopTest();
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 
     @IsTest static void testUpdateCustomerAndInvoice() {
@@ -88,5 +92,6 @@ private class QuickBooksServiceTest {
         System.assertEquals('99', res.id);
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 }

--- a/force-app/main/default/classes/QuickBooksSyncJobTest.cls
+++ b/force-app/main/default/classes/QuickBooksSyncJobTest.cls
@@ -34,6 +34,7 @@ private class QuickBooksSyncJobTest {
         Test.stopTest();
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 
     @IsTest static void testAccountQueueable() {
@@ -49,6 +50,7 @@ private class QuickBooksSyncJobTest {
         Test.stopTest();
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
         a = [SELECT QuickBooks_Customer_Id__c, QuickBooks_Customer_SyncToken__c FROM Account WHERE Id = :a.Id];
         System.assertEquals('77', a.QuickBooks_Customer_Id__c);
         System.assertEquals('2', a.QuickBooks_Customer_SyncToken__c);
@@ -83,6 +85,7 @@ private class QuickBooksSyncJobTest {
         Test.stopTest();
         QuickBooksService.skipDml = false;
         QuickBooksSyncJob.skipAsync = false;
+        QuickBooksTriggerUtil.skipAsync = false;
     }
 
 }

--- a/force-app/main/default/classes/QuickBooksTriggersTest.cls
+++ b/force-app/main/default/classes/QuickBooksTriggersTest.cls
@@ -12,16 +12,19 @@ private class QuickBooksTriggersTest {
     @IsTest static void testAccountTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         Account a = new Account(Name='A');
         Test.startTest();
         insert a;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testPaymentTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         rtms__Load__c load = new rtms__Load__c(Name='L', rtms__Total_Weight__c=1);
         insert load;
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='Inv2', rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
@@ -33,11 +36,13 @@ private class QuickBooksTriggersTest {
         insert p;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 
     @IsTest static void testAccessorialTrigger() {
         Test.setMock(HttpCalloutMock.class, new Mock());
         QuickBooksTriggerUtil.skipAsync = true;
+        QuickBooksSyncJob.skipAsync = true;
         rtms__Load__c load = new rtms__Load__c(Name='L2', rtms__Total_Weight__c=1);
         insert load;
         rtms__CustomerInvoice__c inv = new rtms__CustomerInvoice__c(Name='Inv3', rtms__Load__c=load.Id, rtms__Invoice_Date__c=Date.today(), rtms__Invoice_Due_Date__c=Date.today().addDays(1), rtms__Invoice_Total__c=1);
@@ -54,5 +59,6 @@ private class QuickBooksTriggersTest {
         insert line;
         Test.stopTest();
         System.assertEquals(0, [SELECT COUNT() FROM AsyncApexJob WHERE JobType='Queueable']);
+        QuickBooksSyncJob.skipAsync = false;
     }
 }

--- a/force-app/main/default/triggers/AccountQuickBooksTrigger.trigger
+++ b/force-app/main/default/triggers/AccountQuickBooksTrigger.trigger
@@ -1,5 +1,5 @@
 trigger AccountQuickBooksTrigger on Account (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('Account', new List<Id>(Trigger.newMap.keySet())));
     }
 }

--- a/force-app/main/default/triggers/CustomerInvoiceAccessorialTrigger.trigger
+++ b/force-app/main/default/triggers/CustomerInvoiceAccessorialTrigger.trigger
@@ -1,5 +1,5 @@
 trigger CustomerInvoiceAccessorialTrigger on rtms__CustomerInvoiceAccessorial__c (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerInvoiceAccessorial__c', new List<Id>(Trigger.newMap.keySet())));
     }
 }

--- a/force-app/main/default/triggers/CustomerPaymentTrigger.trigger
+++ b/force-app/main/default/triggers/CustomerPaymentTrigger.trigger
@@ -1,5 +1,5 @@
 trigger CustomerPaymentTrigger on rtms__CustomerPayment__c (after insert, after update) {
-    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !Test.isRunningTest()) {
+    if (Trigger.isAfter && !QuickBooksTriggerUtil.skipAsync && !QuickBooksSyncJob.skipAsync && !Test.isRunningTest()) {
         System.enqueueJob(new QuickBooksSyncJob('rtms__CustomerPayment__c', new List<Id>(Trigger.newMap.keySet())));
     }
 }


### PR DESCRIPTION
## Summary
- avoid enqueuing QuickBooks jobs during tests by checking `QuickBooksSyncJob.skipAsync`
- update trigger unit tests to disable async jobs
- ensure `QuickBooksService` requeries Account with `Name`
- guard QuickBooksScheduler queueable from running in tests
- fix QuickBooksServiceTest to set skip flag in invoice test
- reset skip flags after each QuickBooksSyncJobTest
- reset QuickBooksTriggerUtil flag after sync job tests
- reset QuickBooksTriggerUtil flag after QuickBooksService tests

## Testing
- `./setup_codex.sh validate sandbox` *(fails: Invalid or missing SFDX auth URL)*

------
https://chatgpt.com/codex/tasks/task_e_686150ddb4dc8322aae8bf8f54489e02